### PR TITLE
[FIXED] the Base64 image cached issue

### DIFF
--- a/app/app/carrousel/_components/slideContents/ImageAndTextHorizontal.tsx
+++ b/app/app/carrousel/_components/slideContents/ImageAndTextHorizontal.tsx
@@ -68,6 +68,7 @@ export const ImageAndTextHorizontal = ({
                     >
                         <Image
                             src={image}
+                            loader={()=> image + Date.now()}
                             alt='image'
                             fill
                             className='object-cover h-full'


### PR DESCRIPTION
By comparing, both Before & After, HTML code which was rendering correct and all the URLs were also correct. but It was `next/image` causing the issue, it somehow caching the image, by `loader` param to `Image` solved the issue.

